### PR TITLE
Corrects PSR-4 Namespace

### DIFF
--- a/Classes/ViewHelpers/FeedbackViewHelper.php
+++ b/Classes/ViewHelpers/FeedbackViewHelper.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nitsan\NsFeedback\ViewHelpers;
+namespace NITSAN\NsFeedback\ViewHelpers;
 
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;


### PR DESCRIPTION
idk if this works on windows, but at least Linux is case-sensitive and therefore this extension cannot be installed due to a PSR-4 load error:
> Expected to find class "NITSAN\NsFeedback\ViewHelpers\FeedbackViewHelper" in file "[...]/vendor/nitsan/ns-feedback/Classes/ViewHelpers/FeedbackViewHelper.php" while importing services from resource "../Classes/*", but it was not found! Check the namespace prefix used with the resource